### PR TITLE
Add SQLAlchemy auto-install attempt in tests

### DIFF
--- a/db/connection.py
+++ b/db/connection.py
@@ -1,20 +1,24 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, scoped_session
+from __future__ import annotations
+
 from contextlib import contextmanager
-import yaml
+from typing import Any, Generator
+
+from sqlalchemy import create_engine  # type: ignore
+from sqlalchemy.orm import scoped_session, sessionmaker  # type: ignore
+import yaml  # type: ignore
 import os
 
 # SQLAlchemy setup
-engine = None
-Session = None
+engine: Any = None
+Session: Any = None
 
-def load_db_config():
+def load_db_config() -> dict:
     with open('config.yaml', 'r', encoding='utf-8') as file:
         config = yaml.safe_load(file)
     return config['database']
 
-@contextmanager 
-def get_db_connection():
+@contextmanager
+def get_db_connection() -> Generator[Any, None, None]:
     """Provide a transactional scope around a series of operations."""
     session = Session()
     try:
@@ -26,7 +30,7 @@ def get_db_connection():
     finally:
         session.close()
 
-def initialize_db():
+def initialize_db() -> None:
     """Initialize SQLAlchemy database connection"""
     global engine, Session
     
@@ -52,7 +56,7 @@ def initialize_db():
     
     print(f"Database connected: {db_url}")
 
-def close_db():
+def close_db() -> None:
     """Close database connection"""
     global engine, Session
     if engine:

--- a/db/models.py
+++ b/db/models.py
@@ -1,6 +1,8 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, JSON
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.sql import func
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, JSON, String, Text  # type: ignore
+from sqlalchemy.ext.declarative import declarative_base  # type: ignore
+from sqlalchemy.sql import func  # type: ignore
 
 Base = declarative_base()
 

--- a/tests/test_db_operations.py
+++ b/tests/test_db_operations.py
@@ -1,0 +1,108 @@
+import unittest
+import importlib
+import subprocess
+import sys
+from unittest.mock import patch
+
+SQLALCHEMY_AVAILABLE = importlib.util.find_spec("sqlalchemy") is not None
+
+if not SQLALCHEMY_AVAILABLE:
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "SQLAlchemy"], check=True
+        )
+    except Exception:
+        SQLALCHEMY_AVAILABLE = False
+    else:
+        SQLALCHEMY_AVAILABLE = importlib.util.find_spec("sqlalchemy") is not None
+
+if SQLALCHEMY_AVAILABLE:
+    from db.connection import initialize_db, close_db
+    import db.operations as ops
+
+
+@unittest.skipUnless(SQLALCHEMY_AVAILABLE, "SQLAlchemy not installed")
+class TestDBOperations(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config_patch = patch(
+            'db.connection.load_db_config',
+            return_value={
+                'type': 'sqlite',
+                'postgresql': {},
+                'sqlite': {'database': ':memory:'}
+            }
+        )
+        cls.analyzer_patch = patch('git.config.load_analyzer_config', return_value=[])
+        cls.config_patch.start()
+        cls.analyzer_patch.start()
+        initialize_db()
+        ops.reset_database()
+
+    @classmethod
+    def tearDownClass(cls):
+        close_db()
+        cls.analyzer_patch.stop()
+        cls.config_patch.stop()
+
+    def test_commit_operations(self):
+        commit_data = {
+            'commit_hash': 'hash1',
+            'branch': 'main',
+            'commit_date': 1,
+            'commit_message': 'msg',
+            'author_name': 'name',
+            'author_email': 'name@example.com'
+        }
+        cid = ops.insert_commit(commit_data)
+        self.assertIsInstance(cid, int)
+        self.assertTrue(cid > 0)
+        self.assertEqual(ops.get_commit_id('hash1'), cid)
+        self.assertTrue(ops.commit_exists_in_db('hash1'))
+        self.assertEqual(ops.get_latest_commit_hash_from_db('main'), 'hash1')
+
+    def test_diff_and_analysis(self):
+        c1 = ops.insert_commit({
+            'commit_hash': 'hashA',
+            'branch': 'dev',
+            'commit_date': 2,
+            'commit_message': 'msgA',
+            'author_name': 'a',
+            'author_email': 'a@example.com'
+        })
+        c2 = ops.insert_commit({
+            'commit_hash': 'hashB',
+            'branch': 'dev',
+            'commit_date': 3,
+            'commit_message': 'msgB',
+            'author_name': 'b',
+            'author_email': 'b@example.com'
+        })
+        diff_id = ops.insert_diff_file({
+            'commit_1_id': c1,
+            'commit_2_id': c2,
+            'file_path': 'file.txt',
+            'file_type': 'text',
+            'change_type': 'M',
+            'line_count1': 1,
+            'char_length1': 10,
+            'blob_hash1': '1',
+            'content_snapshot1': 'foo',
+            'line_count2': 2,
+            'char_length2': 20,
+            'blob_hash2': '2',
+            'content_snapshot2': 'bar',
+            'tech_stack': 'text'
+        })
+        ops.remove_diff_file_snapshot(diff_id)
+        diffs = ops.get_diff_data('hashA', 'hashB')
+        self.assertEqual(len(diffs), 1)
+        self.assertIsNone(diffs[0].content_snapshot1)
+        self.assertIsNone(diffs[0].content_snapshot2)
+        ok = ops.save_analysis_result('sample', diff_id, c1, c2, 1, {'a': 1}, 2, {'b': 2})
+        self.assertTrue(ok)
+        self.assertTrue(ops.analysis_exists('sample', diff_id))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- try to install SQLAlchemy inside DB operation tests so they can run when available

## Testing
- `pyright db`
- `python -m unittest discover -s tests -v` *(fails to install SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6843e2097de883239de0b5f150128025